### PR TITLE
fix type errors for escapeRegex method

### DIFF
--- a/structures/handlers/functions.js
+++ b/structures/handlers/functions.js
@@ -32,7 +32,12 @@ function onCoolDown(message, command) {
   }
 }
 
+
+/**
+ * @param {string} str
+ */
 function escapeRegex(str) {
+  if (typeof str !== "string") throw new TypeError("Parameter must be a string");
   try {
     return str.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`);
   } catch (e) {


### PR DESCRIPTION
this patch fixed str parameter validations for a string or empty so it doesn't runs into TypeError str being undefined